### PR TITLE
Add stop API for ChatView

### DIFF
--- a/server/dify.ts
+++ b/server/dify.ts
@@ -1,0 +1,29 @@
+export interface AssistantInfo {
+  baseUrl: string
+  key: string
+}
+
+/**
+ * 调用 Dify 停止接口，停止生成对话消息
+ * @param assistant 助手配置，包含 baseUrl 和 API key
+ * @param taskId 任务 ID，可在流式返回中获取
+ * @param body 请求体，需包含 user 标识
+ * @returns 上游返回的 JSON 结果
+ */
+export async function stopMessage(assistant: AssistantInfo, taskId: string, body: any) {
+  const response = await fetch(`${assistant.baseUrl}/chat-messages/${taskId}/stop`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${assistant.key}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(text || `HTTP ${response.status}`)
+  }
+
+  return response.json()
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import cors from 'cors'
 
 // 导入助手配置管理类
 import { AssistantConfig } from '../src/utils/assistantConfig'
+import { stopMessage } from './dify'
 
 const app = express()
 app.use(cors())
@@ -131,7 +132,7 @@ assistantConfig.waitForInit().then(() => {
   })
 
   app.post('/api/completion-messages', async (req, res) => {
-    const body = req.body || {} 
+    const body = req.body || {}
     const assistantId = req.headers['x-assistant-id'] as string || ''
     
     if (!assistantId) {
@@ -141,6 +142,30 @@ assistantConfig.waitForInit().then(() => {
     
     if (!body.response_mode) body.response_mode = 'streaming'
     await proxyPost(assistantId, '/completion-messages', body, res)
+  })
+
+  app.post('/api/chat-messages/:taskId/stop', async (req, res) => {
+    const body = req.body || {}
+    const assistantId = req.headers['x-assistant-id'] as string || ''
+
+    if (!assistantId) {
+      res.status(400).json({ error: 'Assistant ID is required' })
+      return
+    }
+
+    const assistant = getAssistant(assistantId)
+    if (!assistant) {
+      res.status(404).json({ error: `Assistant with id '${assistantId}' not found` })
+      return
+    }
+
+    try {
+      const result = await stopMessage(assistant, req.params.taskId, body)
+      res.json(result)
+    } catch (e: any) {
+      console.error(e)
+      res.status(500).json({ error: e?.message || 'stop error' })
+    }
   })
 
   // 获取所有助手信息
@@ -160,6 +185,11 @@ app.post('/api/chat-messages', (req, res) => {
 })
 
 app.post('/api/completion-messages', (req, res) => {
+  const assistantId = req.headers['x-assistant-id'] as string || ''
+  res.status(202).json({ message: `Assistant ${assistantId} is still loading. Please try again later.` })
+})
+
+app.post('/api/chat-messages/:taskId/stop', (req, res) => {
   const assistantId = req.headers['x-assistant-id'] as string || ''
   res.status(202).json({ message: `Assistant ${assistantId} is still loading. Please try again later.` })
 })

--- a/src/store/chat.ts
+++ b/src/store/chat.ts
@@ -13,6 +13,7 @@ export interface ChatSession {
   createdAt: number
   updatedAt: number
   streaming?: boolean
+  taskId?: string
 }
 
 export const useChatStore = defineStore('chat', {
@@ -137,6 +138,12 @@ export const useChatStore = defineStore('chat', {
       const s = this.sessions.find(x => x.id === sessionId)
       if (!s) return
       s.streaming = v
+      this.persist()
+    },
+    setTaskId(sessionId: string, taskId?: string) {
+      const s = this.sessions.find(x => x.id === sessionId)
+      if (!s) return
+      s.taskId = taskId
       this.persist()
     }
   }


### PR DESCRIPTION
## Summary
- implement Dify stop API on server and client
- track task ID to allow stopping ongoing responses
- wire ChatView stop button to new API

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf893151c832dbf45dabe70b4eeb8